### PR TITLE
Added check for hash

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -9,7 +9,6 @@ var argv = require('minimist')(process.argv.slice(2), {
     p: 'path'    // path
   }
 })
-
 var setDNSLib = require('../lib')({
   DOApiKey: process.env.DIGITAL_OCEAN
 })
@@ -17,7 +16,14 @@ var setDNSLib = require('../lib')({
 if (argv['test']) {
   setDNSLib.testAccountKey(argv['test'])
 } else if (argv['d'] && argv['p'] && argv['r']) {
-  setDNSLib.setDNS(argv['d'], argv['r'], argv['p'])
+  setDNSLib.testHash(argv['p'], function (err, res) {
+    if (err !== null) {
+      console.log(err)
+      process.exit(1)
+    } else {
+      setDNSLib.setDNS(argv['d'], argv['r'], argv['p'])
+    }
+  })
 } else {
   console.log('Insuffienct arguments supplied.')
   console.log('Please provide: domain, record, and path.')

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,8 @@
 var DigitalOcean = require('do-wrapper')
 var Promise = require('bluebird')
+var http = require('http')
+var isSuccess = require('is-success')
+var isRedirect = require('is-redirect')
 
 module.exports = function initializeModule (options) {
   var api = Promise.promisifyAll(new DigitalOcean(options.DOApiKey, 10))
@@ -11,9 +14,26 @@ module.exports = function initializeModule (options) {
     })
   }
 
+  function testHash (path, cb) {
+    return http.get({
+        host: 'ipfs.io',
+        port: 80,
+        path: path
+      }, function (res) {
+        if (isSuccess(res.statusCode) || isRedirect(res.statusCode)) {
+          console.log('Got status code: ' + res.statusCode)
+          return cb(null, res.statusCode)
+        } else {
+          return cb('Hash invalid: check hash')
+        }
+      }).on('error', function (e) {
+        return cb('Got error: ' + e.message)
+      })
+  }
+
   function getDomainRecord (domainName, domainRecordName, cb) {
     return api.domainRecordsGetAll(domainName, {per_page: 100}, function (err, data) {
-      if (err) {
+      if (err || data.body.id === 'not_found') {
         cb('error: failed to fetch records for domain ' + domainName + ': ' + data.statusMessage);
       } else if (data.statusCode / 100 !== 2) {
         cb('error: failed to fetch records for domain ' + domainName + ': ' + data.statusMessage);
@@ -51,6 +71,7 @@ module.exports = function initializeModule (options) {
 
   return {
     testAccountKey: testAccountKey,
-    setDNS: setDNS
+    setDNS: setDNS,
+    testHash: testHash
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
   "dependencies": {
     "bluebird": "^2.10.0",
     "do-wrapper": "^2.2.0",
+    "is-redirect": "^1.0.0",
+    "is-success": "^1.0.0",
     "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
This checks if the hash works at the ipfs.io gateway, looking for a redirect 302 before continuing. This should close #6.

Also added a better error check for not getting domain records properly.
